### PR TITLE
Add Admin Settings page

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,6 +7,7 @@
 # Files
 /.gitattributes export-ignore
 /.gitignore export-ignore
+/.nvmrc export-ignore
 /.wp-env.json export-ignore
 /composer.json export-ignore
 /composer.lock export-ignore

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -19,7 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      contains(github.event.pull_request.labels.*.name, 'run-e2e')
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' &&
+        contains(github.event.pull_request.labels.*.name, 'run-e2e'))
 
     steps:
     - name: Checkout

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -10,12 +10,16 @@ on:
   pull_request:
     branches:
       - main
+    types: [labeled, synchronize, reopened]
   workflow_dispatch:
 
 jobs:
   e2e:
     name: Cypress E2E Tests
     runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'run-e2e')
 
     steps:
     - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "davekellam/dont-mess-up-prod",
     "description": "A WordPress plugin to indicate which environment you're currently using in the admin bar",
     "type": "wordpress-plugin",
-    "version": "0.9.1",
+    "version": "1.0.0-alpha",
     "keywords": [
         "wordpress",
         "plugin"

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "davekellam/dont-mess-up-prod",
     "description": "A WordPress plugin to indicate which environment you're currently using in the admin bar",
     "type": "wordpress-plugin",
-    "version": "1.0.0-alpha",
+    "version": "1.0.0",
     "keywords": [
         "wordpress",
         "plugin"

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
     "name": "davekellam/dont-mess-up-prod",
     "description": "A WordPress plugin to indicate which environment you're currently using in the admin bar",
     "type": "wordpress-plugin",
-    "version": "1.0.0",
     "keywords": [
         "wordpress",
         "plugin"

--- a/cypress/e2e/admin-settings.cy.js
+++ b/cypress/e2e/admin-settings.cy.js
@@ -13,8 +13,8 @@ describe("Admin Settings - Environment Configuration", () => {
     const environments = ["local", "development", "staging", "production"]
 
     environments.forEach((env) => {
-      cy.get(`#dmup_color_${env}`).should("exist")
-      cy.get(`#dmup_url_${env}`).should("exist")
+      cy.get(`#dmup_settings_${env}_color`).should("exist")
+      cy.get(`#dmup_settings_${env}_url`).should("exist")
     })
   })
 

--- a/cypress/e2e/admin-settings.cy.js
+++ b/cypress/e2e/admin-settings.cy.js
@@ -1,0 +1,24 @@
+describe("Admin Settings - Environment Configuration", () => {
+  beforeEach(() => {
+    cy.wpLogin()
+    cy.visit("/wp-admin/options-general.php?page=dont-mess-up-prod")
+  })
+
+  it("should load the settings page", () => {
+    cy.get("h1").should("contain.text", "Don't Mess Up Prod")
+    cy.contains("Environment Configuration").should("be.visible")
+  })
+
+  it("should render color and URL fields for each environment", () => {
+    const environments = ["local", "development", "staging", "production"]
+
+    environments.forEach((env) => {
+      cy.get(`#dmup_color_${env}`).should("exist")
+      cy.get(`#dmup_url_${env}`).should("exist")
+    })
+  })
+
+  it("should show the Save Settings button", () => {
+    cy.contains('input[type="submit"], button', "Save Settings").should("be.visible")
+  })
+})

--- a/dont-mess-up-prod.php
+++ b/dont-mess-up-prod.php
@@ -19,6 +19,8 @@
 
 namespace DontMessUpProd;
 
+if ( ! defined( 'ABSPATH' ) ) { exit; } // Exit if accessed directly
+
 define( 'DONT_MESS_UP_PROD_VERSION', '1.0.0-alpha' );
 
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-environment-indicator.php';

--- a/dont-mess-up-prod.php
+++ b/dont-mess-up-prod.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Don't Mess Up Prod
  * Plugin URI:        https://github.com/davekellam/dont-mess-up-prod
  * Description:       Displays the current environment in the admin bar
- * Version:           1.0.0-alpha
+ * Version:           1.0.0
  * Requires at least: 6.7
  * Requires PHP:      8.0
  * Author:            Dave Kellam
@@ -21,7 +21,7 @@ namespace DontMessUpProd;
 
 if ( ! defined( 'ABSPATH' ) ) { exit; } // Exit if accessed directly
 
-define( 'DONT_MESS_UP_PROD_VERSION', '1.0.0-alpha' );
+define( 'DONT_MESS_UP_PROD_VERSION', '1.0.0' );
 
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-environment-indicator.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-admin-settings.php';

--- a/dont-mess-up-prod.php
+++ b/dont-mess-up-prod.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Don't Mess Up Prod
  * Plugin URI:        https://github.com/davekellam/dont-mess-up-prod
  * Description:       Displays the current environment in the admin bar
- * Version:           0.9.1
+ * Version:           1.0.0-alpha
  * Requires at least: 6.7
  * Requires PHP:      8.0
  * Author:            Dave Kellam
@@ -19,7 +19,13 @@
 
 namespace DontMessUpProd;
 
-define( 'DONT_MESS_UP_PROD_VERSION', '0.9.1' );
+define( 'DONT_MESS_UP_PROD_VERSION', '1.0.0-alpha' );
 
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-environment-indicator.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-admin-settings.php';
+
 Environment_Indicator::get_instance();
+
+if ( is_admin() ) {
+	Admin_Settings::get_instance();
+}

--- a/dont-mess-up-prod.php
+++ b/dont-mess-up-prod.php
@@ -25,7 +25,4 @@ require_once plugin_dir_path( __FILE__ ) . 'includes/class-environment-indicator
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-admin-settings.php';
 
 Environment_Indicator::get_instance();
-
-if ( is_admin() ) {
-	Admin_Settings::get_instance();
-}
+Admin_Settings::get_instance();

--- a/includes/class-admin-settings.php
+++ b/includes/class-admin-settings.php
@@ -1,0 +1,269 @@
+<?php
+/**
+ * Admin Settings Class
+ *
+ * Handles the admin interface for configuring environment settings
+ *
+ * @package DontMessUpProd
+ * @since   1.0.0
+ */
+
+namespace DontMessUpProd;
+
+/**
+ * Admin Settings Class
+ *
+ * Manages the settings page and configuration options for environment colors and URLs
+ */
+class Admin_Settings {
+	/**
+	 * Cached singleton instance
+	 *
+	 * @var self|null
+	 */
+	private static ?self $instance = null;
+
+	/**
+	 * Settings group name
+	 *
+	 * @var string
+	 */
+	private const SETTINGS_GROUP = 'dmup_settings';
+
+	/**
+	 * Settings page slug
+	 *
+	 * @var string
+	 */
+	private const PAGE_SLUG = 'dont-mess-up-prod';
+
+	/**
+	 * Environment definitions
+	 *
+	 * @var array<string, string>
+	 */
+	private array $environments = [
+		'local'       => 'Local',
+		'development' => 'Development',
+		'staging'     => 'Staging',
+		'production'  => 'Production',
+	];
+
+	/**
+	 * Gets the singleton instance of the Admin_Settings class
+	 *
+	 * @return self
+	 */
+	public static function get_instance(): self {
+		if ( null === static::$instance ) {
+			static::$instance = new static();
+			static::$instance->add_hooks();
+		}
+
+		return static::$instance;
+	}
+
+	/**
+	 * Use get_instance() instead
+	 */
+	private function __construct() {}
+
+	/**
+	 * Add WordPress hooks
+	 *
+	 * @return void
+	 */
+	public function add_hooks(): void {
+		add_action( 'admin_menu', [ $this, 'add_settings_page' ] );
+		add_action( 'admin_init', [ $this, 'register_settings' ] );
+		add_filter( 'dmup_environment_colors', [ $this, 'apply_saved_colors' ], 20 );
+		add_filter( 'dmup_environment_urls', [ $this, 'apply_saved_urls' ], 20 );
+	}
+
+	/**
+	 * Add settings page to WordPress admin menu
+	 *
+	 * @return void
+	 */
+	public function add_settings_page(): void {
+		add_options_page(
+			__( 'Don\'t Mess Up Prod Settings', 'dont-mess-up-prod' ),
+			__( 'Don\'t Mess Up Prod', 'dont-mess-up-prod' ),
+			'manage_options',
+			self::PAGE_SLUG,
+			[ $this, 'render_settings_page' ]
+		);
+	}
+
+	/**
+	 * Register settings and fields
+	 *
+	 * @return void
+	 */
+	public function register_settings(): void {
+		$default_colors = Environment_Indicator::get_instance()->get_default_colors();
+
+		// Register settings for each environment
+		foreach ( $this->environments as $env => $label ) {
+			// Register color setting
+			register_setting(
+				self::SETTINGS_GROUP,
+				"dmup_color_{$env}",
+				[
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_hex_color',
+					'default'           => $default_colors[ $env ],
+				]
+			);
+
+			// Register URL setting
+			register_setting(
+				self::SETTINGS_GROUP,
+				"dmup_url_{$env}",
+				[
+					'type'              => 'string',
+					'sanitize_callback' => 'esc_url_raw',
+					'default'           => '',
+				]
+			);
+		}
+
+		// Add settings section
+		add_settings_section(
+			'dmup_environments_section',
+			__( 'Environment Configuration', 'dont-mess-up-prod' ),
+			[ $this, 'render_section_description' ],
+			self::PAGE_SLUG
+		);
+
+		// Add fields for each environment
+		foreach ( $this->environments as $env => $label ) {
+			add_settings_field(
+				"dmup_{$env}_settings",
+				$label,
+				[ $this, 'render_environment_fields' ],
+				self::PAGE_SLUG,
+				'dmup_environments_section',
+				[ 'environment' => $env ]
+			);
+		}
+	}
+
+	/**
+	 * Render the settings page
+	 *
+	 * @return void
+	 */
+	public function render_settings_page(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+		?>
+		<div class="wrap">
+			<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
+			<form action="options.php" method="post">
+				<?php
+				settings_fields( self::SETTINGS_GROUP );
+				do_settings_sections( self::PAGE_SLUG );
+				submit_button( __( 'Save Settings', 'dont-mess-up-prod' ) );
+				?>
+			</form>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Render the section description
+	 *
+	 * @return void
+	 */
+	public function render_section_description(): void {
+		?>
+		<p>
+			<?php
+			esc_html_e(
+				'Configure the colors and URLs for each environment. The environment indicator will use these settings to display the appropriate color and provide quick links to other environments.',
+				'dont-mess-up-prod'
+			);
+			?>
+		</p>
+		<?php
+	}
+
+	/**
+	 * Render environment fields (color and URL)
+	 *
+	 * @param array $args Field arguments containing the environment key
+	 * @return void
+	 */
+	public function render_environment_fields( array $args ): void {
+		$env            = $args['environment'];
+		$default_colors = Environment_Indicator::get_instance()->get_default_colors();
+		$color_option   = "dmup_color_{$env}";
+		$url_option     = "dmup_url_{$env}";
+		$color_value    = get_option( $color_option, $default_colors[ $env ] );
+		$url_value      = get_option( $url_option, '' );
+		?>
+		<div style="margin-bottom: 10px;">
+			<label for="<?php echo esc_attr( $color_option ); ?>" style="display: inline-block; width: 80px;">
+				<?php esc_html_e( 'Color:', 'dont-mess-up-prod' ); ?>
+			</label>
+			<input 
+				type="color" 
+				id="<?php echo esc_attr( $color_option ); ?>" 
+				name="<?php echo esc_attr( $color_option ); ?>" 
+				value="<?php echo esc_attr( $color_value ); ?>"
+				style="width: 60px; height: 30px; vertical-align: middle;"
+			/>
+			<code style="margin-left: 10px; vertical-align: middle;"><?php echo esc_html( $color_value ); ?></code>
+		</div>
+		<div>
+			<label for="<?php echo esc_attr( $url_option ); ?>" style="display: inline-block; width: 80px;">
+				<?php esc_html_e( 'URL:', 'dont-mess-up-prod' ); ?>
+			</label>
+			<input 
+				type="url" 
+				id="<?php echo esc_attr( $url_option ); ?>" 
+				name="<?php echo esc_attr( $url_option ); ?>" 
+				value="<?php echo esc_attr( $url_value ); ?>"
+				placeholder="<?php esc_attr_e( 'https://example.com', 'dont-mess-up-prod' ); ?>"
+				class="regular-text"
+			/>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Apply saved colors to the environment colors filter
+	 *
+	 * @param array $colors Default colors array
+	 * @return array Modified colors array
+	 */
+	public function apply_saved_colors( array $colors ): array {
+		foreach ( $this->environments as $env => $label ) {
+			$saved_color = get_option( "dmup_color_{$env}" );
+			if ( $saved_color ) {
+				$colors[ $env ] = $saved_color;
+			}
+		}
+
+		return $colors;
+	}
+
+	/**
+	 * Apply saved URLs to the environment URLs filter
+	 *
+	 * @param array $urls Default URLs array
+	 * @return array Modified URLs array
+	 */
+	public function apply_saved_urls( array $urls ): array {
+		foreach ( $this->environments as $env => $label ) {
+			$saved_url = get_option( "dmup_url_{$env}" );
+			if ( $saved_url ) {
+				$urls[ $env ] = $saved_url;
+			}
+		}
+
+		return $urls;
+	}
+}

--- a/includes/class-admin-settings.php
+++ b/includes/class-admin-settings.php
@@ -40,13 +40,13 @@ class Admin_Settings {
 	/**
 	 * Environment definitions
 	 *
-	 * @var array<string, string>
+	 * @var array<string>
 	 */
 	private array $environments = [
-		'local'       => 'Local',
-		'development' => 'Development',
-		'staging'     => 'Staging',
-		'production'  => 'Production',
+		'local',
+		'development',
+		'staging',
+		'production',
 	];
 
 	/**
@@ -104,7 +104,7 @@ class Admin_Settings {
 		$default_colors = Environment_Indicator::get_instance()->get_default_colors();
 
 		// Register settings for each environment
-		foreach ( $this->environments as $env => $label ) {
+		foreach ( $this->environments as $env ) {
 			// Register color setting
 			register_setting(
 				self::SETTINGS_GROUP,
@@ -137,10 +137,10 @@ class Admin_Settings {
 		);
 
 		// Add fields for each environment
-		foreach ( $this->environments as $env => $label ) {
+		foreach ( $this->environments as $env ) {
 			add_settings_field(
 				"dmup_{$env}_settings",
-				$label,
+				ucwords( $env ),
 				[ $this, 'render_environment_fields' ],
 				self::PAGE_SLUG,
 				'dmup_environments_section',
@@ -240,7 +240,7 @@ class Admin_Settings {
 	 * @return array Modified colors array
 	 */
 	public function apply_saved_colors( array $colors ): array {
-		foreach ( $this->environments as $env => $label ) {
+		foreach ( $this->environments as $env ) {
 			$saved_color = get_option( "dmup_color_{$env}" );
 			if ( $saved_color ) {
 				$colors[ $env ] = $saved_color;
@@ -257,7 +257,7 @@ class Admin_Settings {
 	 * @return array Modified URLs array
 	 */
 	public function apply_saved_urls( array $urls ): array {
-		foreach ( $this->environments as $env => $label ) {
+		foreach ( $this->environments as $env ) {
 			$saved_url = get_option( "dmup_url_{$env}" );
 			if ( $saved_url ) {
 				$urls[ $env ] = $saved_url;

--- a/includes/class-admin-settings.php
+++ b/includes/class-admin-settings.php
@@ -40,6 +40,8 @@ class Admin_Settings {
 	/**
 	 * Environment definitions
 	 *
+	 * These are currently hardcoded into WordPress with no way to retrieve.
+	 *
 	 * @var array<string>
 	 */
 	private array $environments = [
@@ -174,7 +176,9 @@ class Admin_Settings {
 	}
 
 	/**
-	 * Render environment fields (color and URL)
+	 * Render environment fields
+	 *
+	 * Will produce the color picker and URL input for each of the environments
 	 *
 	 * @param array $args Field arguments containing the environment key
 	 * @return void
@@ -241,10 +245,12 @@ class Admin_Settings {
 				$url = esc_url_raw( $env_settings['url'] );
 			}
 
+			// ignore if color is default
 			if ( $color && $color !== $default_colors[ $env ] ) {
 				$sanitized[ $env ]['color'] = $color;
 			}
 
+			// ignore if URL is empty (will silently remove invalid urls though)
 			if ( '' !== $url ) {
 				$sanitized[ $env ]['url'] = $url;
 			}

--- a/includes/class-admin-settings.php
+++ b/includes/class-admin-settings.php
@@ -10,6 +10,8 @@
 
 namespace DontMessUpProd;
 
+if ( ! defined( 'ABSPATH' ) ) { exit; } // Exit if accessed directly
+
 /**
  * Admin Settings Class
  *

--- a/includes/class-environment-indicator.php
+++ b/includes/class-environment-indicator.php
@@ -183,6 +183,17 @@ class Environment_Indicator {
 	}
 
 	/**
+	 * Gets the default environment colors without filters
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, string> Default environment colors array
+	 */
+	public function get_default_colors(): array {
+		return $this->default_colors;
+	}
+
+	/**
 	 * Gets environment colors with filter support
 	 *
 	 * @return array<string, string> Environment colors array

--- a/includes/class-environment-indicator.php
+++ b/includes/class-environment-indicator.php
@@ -10,6 +10,8 @@
 
 namespace DontMessUpProd;
 
+if ( ! defined( 'ABSPATH' ) ) { exit; } // Exit if accessed directly
+
 use WP_Admin_Bar;
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dont-mess-up-prod",
-  "version": "0.9.1",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dont-mess-up-prod",
-      "version": "0.9.1",
+      "version": "1.0.0",
       "license": "GPL-2.0-or-later",
       "devDependencies": {
         "@wordpress/env": "10.37.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dont-mess-up-prod",
-  "version": "0.9.1",
+  "version": "1.0.0-alpha",
   "description": "WordPress plugin to indicate which environment you're currently using in the admin bar",
   "scripts": {
     "cy:open": "cypress open",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dont-mess-up-prod",
-  "version": "1.0.0-alpha",
+  "version": "1.0.0",
   "description": "WordPress plugin to indicate which environment you're currently using in the admin bar",
   "scripts": {
     "cy:open": "cypress open",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: environment, admin bar, development, debug
 Requires at least: 6.7
 Tested up to: 6.9
 Requires PHP: 8.0
-Stable tag: 0.9.1
+Stable tag: 1.0.0-alpha
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: environment, admin bar, development, debug
 Requires at least: 6.7
 Tested up to: 6.9
 Requires PHP: 8.0
-Stable tag: 1.0.0-alpha
+Stable tag: 1.0.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -93,6 +93,9 @@ add_filter( 'dmup_environment_urls', function() {
 5. Staging environment indicator with environment switcher menu
 
 == Changelog ==
+
+= 1.0.0 =
+* Adding admin settings page
 
 = 0.9.1 =
 * Initial wordpress.org release


### PR DESCRIPTION
- Add new Admin_Settings class with settings page under Settings menu
- Allow admins to configure colors and URLs for all 4 environments
- Settings integrate via existing dmup_environment_colors and dmup_environment_urls filters (priority 20)
- Remove duplicate default_colors array, centralize in Environment_Indicator
- Add get_default_colors() method to Environment_Indicator
- Bump version to 1.0.0-alpha
---

🤖
This pull request introduces a major update to the "Don't Mess Up Prod" WordPress plugin, focusing on adding a configurable admin settings page for environment colors and URLs, improving test coverage, and preparing for a new release. The most significant changes include the implementation of a new settings interface, updates to plugin versioning, and enhancements to automated testing workflows.

**Admin Settings and Configuration:**

* Introduced a new `Admin_Settings` class (`includes/class-admin-settings.php`) that provides a WordPress admin settings page, allowing users to configure environment-specific colors and URLs. This includes registration of settings, rendering of fields, sanitization, and integration with the environment indicator.
* Updated the plugin bootstrap (`dont-mess-up-prod.php`) to load the new `Admin_Settings` class and initialize it only in the admin context.

**Testing Enhancements:**

* Added new Cypress end-to-end tests (`cypress/e2e/admin-settings.cy.js`) to verify the presence and functionality of the admin settings page, including color and URL fields for each environment and the "Save Settings" button.
* Modified the E2E GitHub Actions workflow (`.github/workflows/e2e-tests.yml`) to allow manual triggering and to run tests when the `run-e2e` label is present on a pull request.

**Plugin Versioning and Metadata:**

* Bumped the plugin version from `0.9.1` to `1.0.0-alpha` in `composer.json`, `package.json`, `dont-mess-up-prod.php`, and `readme.txt` to reflect the new features and pre-release status. [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L5-R5) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[3]](diffhunk://#diff-e7866d901524b5253cfd8b8dc95ef6ec6c7903076300c71cc5f2383beb45efe8L6-R6) [[4]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L7-R7)
* Updated the internal version constant to `1.0.0-alpha` in `dont-mess-up-prod.php`.

**Support for Environment Indicator:**

* Added a `get_default_colors()` method to the `Environment_Indicator` class to allow the settings page to retrieve unfiltered default environment colors.